### PR TITLE
Default Attributes are now added on top of character upgraded attributes

### DIFF
--- a/src/main/java/com/atherys/rpg/api/character/RPGCharacter.java
+++ b/src/main/java/com/atherys/rpg/api/character/RPGCharacter.java
@@ -18,9 +18,36 @@ public interface RPGCharacter<T extends Living & Equipable> extends SpongeIdenti
 
     void setEntity(T entity);
 
-    Map<AttributeType, Double> getBaseAttributes();
+    /**
+     * Gets the current Character Attributes
+     * @return Map of Character Attributes
+     */
+    Map<AttributeType, Double> getCharacterAttributes();
 
+    /**
+     * Set a Character attribute to a specific value
+     * @param type Attribute to set
+     * @param value Value to set to
+     */
+    void setCharacterAttribute(AttributeType type, Double value);
+
+    /**
+     * Add a value to an existing character attribute
+     * @param type Attribute to add
+     * @param amount Amount to add
+     */
+    void addCharacterAttribute(AttributeType type, Double amount);
+
+    /**
+     * Gets the current Buffed Attributes
+     * @return Map of Attributes provided by buffs
+     */
     Map<AttributeType, Double> getBuffAttributes();
 
-    void setBuffAttributes(Map<AttributeType, Double> attributes);
+    /**
+     * Merge the values of the two attribute type maps by adding them together
+     * @param additional Attributes to add
+     */
+    void mergeBuffAttributes(Map<AttributeType, Double> additional);
+
 }

--- a/src/main/java/com/atherys/rpg/api/effect/TemporaryAttributesEffect.java
+++ b/src/main/java/com/atherys/rpg/api/effect/TemporaryAttributesEffect.java
@@ -24,10 +24,7 @@ public class TemporaryAttributesEffect extends TemporaryEffect {
     protected boolean apply(ApplyableCarrier<?> character) {
         character.getLiving().ifPresent(living -> {
             RPGCharacter<?> rpgCharacter = AtherysRPG.getInstance().getCharacterService().getOrCreateCharacter(living);
-            AtherysRPG.getInstance().getAttributeService().mergeAttributes(
-                    rpgCharacter.getBuffAttributes(),
-                    attributeIncreases
-            );
+            AtherysRPG.getInstance().getAttributeFacade().mergeBuffAttributes(rpgCharacter, attributeIncreases);
         });
         return true;
     }
@@ -36,10 +33,7 @@ public class TemporaryAttributesEffect extends TemporaryEffect {
     protected boolean remove(ApplyableCarrier<?> character) {
         character.getLiving().ifPresent(living -> {
             RPGCharacter<?> rpgCharacter = AtherysRPG.getInstance().getCharacterService().getOrCreateCharacter(living);
-            AtherysRPG.getInstance().getAttributeService().mergeAttributes(
-                    rpgCharacter.getBuffAttributes(),
-                    attributeDecreases
-            );
+            AtherysRPG.getInstance().getAttributeFacade().mergeBuffAttributes(rpgCharacter, attributeDecreases);
         });
 
         return true;

--- a/src/main/java/com/atherys/rpg/character/PlayerCharacter.java
+++ b/src/main/java/com/atherys/rpg/character/PlayerCharacter.java
@@ -22,13 +22,21 @@ public class PlayerCharacter implements RPGCharacter<Player> {
     @Transient
     private boolean hasJoined;
 
+    /**
+     * Attributes the player has leveled up, not including the default attribute amount
+     * from the configuration
+     * Only Upgradable Attributes should be stored within this map
+     */
     @Convert(attributeName = "key.", converter = AttributeTypeConverter.class)
     @ElementCollection(fetch = FetchType.EAGER)
     @MapKeyColumn(name = "attribute_type")
     @Column(name = "value")
     @CollectionTable(schema = "atherysrpg", name = "PlayerCharacter_attributes")
-    private Map<AttributeType, Double> baseAttributes = new HashMap<>();
+    private Map<AttributeType, Double> characterAttributes = new HashMap<>();
 
+    /**
+     * Attributes that come from temporary sources
+     */
     @Transient
     private Map<AttributeType, Double> buffAttributes = new HashMap<>();
 
@@ -75,21 +83,32 @@ public class PlayerCharacter implements RPGCharacter<Player> {
     }
 
     @Override
-    public Map<AttributeType, Double> getBaseAttributes() {
-        return baseAttributes;
+    public Map<AttributeType, Double> getCharacterAttributes() {
+        return Collections.unmodifiableMap(characterAttributes);
     }
 
-    public void setBaseAttributes(Map<AttributeType, Double> baseAttributes) {
-        this.baseAttributes = baseAttributes;
+    @Override
+    public void setCharacterAttribute(AttributeType type, Double value) {
+        characterAttributes.put(type, value);
+    }
+
+    @Override
+    public void addCharacterAttribute(AttributeType type, Double amount) {
+        characterAttributes.merge(type, amount, Double::sum);
+    }
+
+    public void setCharacterAttributes(Map<AttributeType, Double> characterAttributes) {
+        this.characterAttributes = characterAttributes;
     }
 
     @Override
     public Map<AttributeType, Double> getBuffAttributes() {
-        return buffAttributes;
+        return Collections.unmodifiableMap(buffAttributes);
     }
 
-    public void setBuffAttributes(Map<AttributeType, Double> buffAttributes) {
-        this.buffAttributes = buffAttributes;
+    @Override
+    public void mergeBuffAttributes(Map<AttributeType, Double> additional) {
+        additional.forEach((type, value) -> buffAttributes.merge(type, value, Double::sum));
     }
 
     public double getExperience() {

--- a/src/main/java/com/atherys/rpg/character/SimpleCharacter.java
+++ b/src/main/java/com/atherys/rpg/character/SimpleCharacter.java
@@ -17,14 +17,14 @@ public class SimpleCharacter<T extends Living & Equipable> implements RPGCharact
 
     private T entity;
 
-    private Map<AttributeType, Double> baseAttributes;
+    private Map<AttributeType, Double> characterAttributes;
 
     private Map<AttributeType, Double> buffAttributes;
 
-    public SimpleCharacter(T entity, Map<AttributeType, Double> baseAttributes) {
+    public SimpleCharacter(T entity, Map<AttributeType, Double> characterAttributes) {
         this.id = entity.getUniqueId();
         this.entity = entity;
-        this.baseAttributes = baseAttributes;
+        this.characterAttributes = characterAttributes;
         this.buffAttributes = new HashMap<>();
     }
 
@@ -44,12 +44,22 @@ public class SimpleCharacter<T extends Living & Equipable> implements RPGCharact
     }
 
     @Override
-    public Map<AttributeType, Double> getBaseAttributes() {
-        return baseAttributes;
+    public Map<AttributeType, Double> getCharacterAttributes() {
+        return characterAttributes;
     }
 
-    public void setBaseAttributes(Map<AttributeType, Double> baseAttributes) {
-        this.baseAttributes = baseAttributes;
+    @Override
+    public void setCharacterAttribute(AttributeType type, Double value) {
+        characterAttributes.put(type, value);
+    }
+
+    @Override
+    public void addCharacterAttribute(AttributeType type, Double amount) {
+        characterAttributes.merge(type, amount, Double::sum);
+    }
+
+    public void setCharacterAttributes(Map<AttributeType, Double> characterAttributes) {
+        this.characterAttributes = characterAttributes;
     }
 
     @Override
@@ -57,7 +67,9 @@ public class SimpleCharacter<T extends Living & Equipable> implements RPGCharact
         return buffAttributes;
     }
 
-    public void setBuffAttributes(Map<AttributeType, Double> buffAttributes) {
-        this.buffAttributes = baseAttributes;
+    @Override
+    public void mergeBuffAttributes(Map<AttributeType, Double> additional) {
+        additional.forEach((type, value) -> buffAttributes.merge(type, value, Double::sum));
     }
+
 }

--- a/src/main/java/com/atherys/rpg/facade/MobFacade.java
+++ b/src/main/java/com/atherys/rpg/facade/MobFacade.java
@@ -49,13 +49,10 @@ public class MobFacade {
     private MobsConfig mobsConfig;
 
     @Inject
-    private AttributeFacade attributeFacade;
+    private AttributeService attributeService;
 
     @Inject
     private RPGCharacterService characterService;
-
-    @Inject
-    private AttributeService attributeService;
 
     @Inject
     private RPGCharacterFacade characterFacade;

--- a/src/main/java/com/atherys/rpg/facade/RPGCharacterFacade.java
+++ b/src/main/java/com/atherys/rpg/facade/RPGCharacterFacade.java
@@ -71,9 +71,6 @@ public class RPGCharacterFacade {
     private AttributeFacade attributeFacade;
 
     @Inject
-    private AttributeService attributeService;
-
-    @Inject
     private RPGSkillFacade skillFacade;
 
     @Inject
@@ -155,16 +152,6 @@ public class RPGCharacterFacade {
             characterService.resetCharacter(pc);
             characterService.addSkill(pc, skillGraphFacade.getSkillGraphRoot());
             rpgMsg.info(player, "The server's skill tree has changed. Your attributes and skill tree have been reset.");
-        }
-    }
-
-    public void checkAttributesDefaults(PlayerCharacter pc) {
-        Map<AttributeType, Double> attributes = attributeService.getBaseAttributes(pc);
-
-        for (AttributeType type : Sponge.getRegistry().getAllOf(AttributeType.class)) {
-            if (!attributes.containsKey(type) || type.isResetOnLogin() || attributes.get(type) < type.getDefaultValue()) {
-                characterService.setAttribute(pc, type, type.getDefaultValue());
-            }
         }
     }
 
@@ -265,8 +252,6 @@ public class RPGCharacterFacade {
 
     public void onResourceRegen(ResourceEvent.Regen event, Player player) {
         double amount = characterService.calcResourceRegen(attributeFacade.getAllAttributes(player));
-
-
         event.setRegenAmount(amount);
     }
 
@@ -421,7 +406,6 @@ public class RPGCharacterFacade {
         setPlayerHealth(player, fill);
         setPlayerResourceLimit(player, fill);
         checkTreeOnLogin(player);
-        checkAttributesDefaults(pc);
     }
 
     public void onPlayerRespawn(Player player) {

--- a/src/main/java/com/atherys/rpg/service/DamageService.java
+++ b/src/main/java/com/atherys/rpg/service/DamageService.java
@@ -20,9 +20,6 @@ public class DamageService {
     private AtherysRPGConfig config;
 
     @Inject
-    private AttributeService attributeService;
-
-    @Inject
     private ExpressionService expressionService;
 
     public DamageService() {

--- a/src/main/java/com/atherys/rpg/service/HealingService.java
+++ b/src/main/java/com/atherys/rpg/service/HealingService.java
@@ -19,9 +19,6 @@ public class HealingService {
     private ExpressionService expressionService;
 
     @Inject
-    private AttributeService attributeService;
-
-    @Inject
     private RPGCharacterService characterService;
 
     private Task healthRegenTask;


### PR DESCRIPTION
**Removed the AttributeService** 
This wasn't really acting like a service, was only calling on the Character Service to do the actual persisting of entity changes.
Believe most of this code was more like a Facade layer action.

**Made Character Getters Unmodifiable**
These should only be modified by services, preventing any badly coded skills from changing these values
Added a few more modifier to support modification to the maps within the Character class

**Renamed BaseAttributes to CharacterAttributes**
Character = Leveled up attributes
base = default + character
